### PR TITLE
feat: 메뉴 조회기능 추가

### DIFF
--- a/src/main/java/com/sparta/chairingproject/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/chairingproject/domain/menu/controller/MenuController.java
@@ -1,5 +1,7 @@
 package com.sparta.chairingproject.domain.menu.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +18,7 @@ import com.sparta.chairingproject.domain.common.dto.RequestDto;
 import com.sparta.chairingproject.domain.menu.dto.request.MenuRequest;
 import com.sparta.chairingproject.domain.menu.dto.request.MenuUpdateRequest;
 import com.sparta.chairingproject.domain.menu.dto.response.MenuDeleteResponse;
+import com.sparta.chairingproject.domain.menu.dto.response.MenuDetailResponse;
 import com.sparta.chairingproject.domain.menu.dto.response.MenuResponse;
 import com.sparta.chairingproject.domain.menu.dto.response.MenuUpdateResponse;
 import com.sparta.chairingproject.domain.menu.service.MenuService;
@@ -60,5 +63,15 @@ public class MenuController {
 		@RequestBody RequestDto request
 	) {
 		return ResponseEntity.ok(menuService.deleteMenu(storeId, menuId, authMember.getMember(), request));
+	}
+
+	@Secured("ROLE_OWNER")
+	@DeleteMapping("/menus")
+	public ResponseEntity<List<MenuDetailResponse>> getAllMenusByStore(
+		@PathVariable Long storeId,
+		@AuthenticationPrincipal UserDetailsImpl authMember
+	) {
+		List<MenuDetailResponse> menus = menuService.getAllMenusByStore(storeId, authMember.getMember());
+		return ResponseEntity.ok(menus);
 	}
 }

--- a/src/main/java/com/sparta/chairingproject/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/chairingproject/domain/menu/controller/MenuController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -66,7 +67,7 @@ public class MenuController {
 	}
 
 	@Secured("ROLE_OWNER")
-	@DeleteMapping("/menus")
+	@GetMapping("/menus")
 	public ResponseEntity<List<MenuDetailResponse>> getAllMenusByStore(
 		@PathVariable Long storeId,
 		@AuthenticationPrincipal UserDetailsImpl authMember

--- a/src/main/java/com/sparta/chairingproject/domain/menu/dto/response/MenuDetailResponse.java
+++ b/src/main/java/com/sparta/chairingproject/domain/menu/dto/response/MenuDetailResponse.java
@@ -1,0 +1,28 @@
+package com.sparta.chairingproject.domain.menu.dto.response;
+
+import com.sparta.chairingproject.domain.menu.entity.Menu;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MenuDetailResponse {
+	private Long id;
+	private String name;
+	private int price;
+	private String image;
+	private boolean inActive;
+
+	public static MenuDetailResponse from(Menu menu) {
+		return MenuDetailResponse.builder()
+			.id(menu.getId())
+			.name(menu.getName())
+			.price(menu.getPrice())
+			.image(menu.getImage())
+			.inActive(menu.isInActive())
+			.build();
+	}
+}

--- a/src/main/java/com/sparta/chairingproject/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/chairingproject/domain/menu/repository/MenuRepository.java
@@ -23,4 +23,6 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 	Optional<Menu> findByIdAndStoreIdAndInActiveFalse(Long menuId, Long storeId);
 
 	List<Menu> findByStoreId(Long storeId);
+
+	List<Menu> findAllByStoreId(Long storeId);
 }

--- a/src/main/java/com/sparta/chairingproject/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/chairingproject/domain/store/controller/StoreController.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -56,7 +57,7 @@ public class StoreController {
 	@GetMapping("/owners/stores/{storeId}/orders")
 	public ResponseEntity<Page<OrderPageResponse>> getOrdersByStore(
 		@PathVariable Long storeId,
-		@PageableDefault(page = 1, size = 5, sort = "createdAt,desc") Pageable pageable,
+		@PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate startDate,
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate endDate,
 		@RequestParam(required = false, defaultValue = "2") int days


### PR DESCRIPTION

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. "어떻게 수정했는가?" 보다 "무엇을 왜 수정했는지?" 설명해주세요. -->
- 사장님이 자신의 가게에 등록된 모든 메뉴를 조회한다.
- 가게에 등록된 메뉴는 한정적이기 때문에 페이징처리는 따로하지 않는다
- 사장님이 메뉴 수정하기전 메뉴를 조회하는 로직이기 떄문에, `inActive` 필드가 `true` 여도 전부 조회한다.
<!---- Resolves: #64   -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).