### PR TITLE
feat: 메세지 재전송 기능 추가

### DIFF
--- a/src/main/java/com/sparta/chairingproject/domain/order/service/OrderNotificationService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/service/OrderNotificationService.java
@@ -1,13 +1,17 @@
 package com.sparta.chairingproject.domain.order.service;
 
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.sparta.chairingproject.config.websocket.WebSocketHandler;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -18,6 +22,8 @@ public class OrderNotificationService {
 	private final Cache<String, Boolean> processedMessages = Caffeine.newBuilder()
 		.expireAfterWrite(10, TimeUnit.MINUTES)
 		.build();
+	// 실패 메세지 이곳에 저장
+	private final Queue<NotificationMessage> retryQueue = new ConcurrentLinkedQueue<>();
 
 	public void sendNotification(Long memberId, String message) {
 		String messageId = extractMessageId(message);
@@ -25,15 +31,57 @@ public class OrderNotificationService {
 			System.out.println("중복 메세지 필터링: Message Id: " + messageId);
 			return;
 		}
-		// WebSocket 에 메세지 전송
-		webSocketHandler.sendMessageToUser(memberId, message);
 
-		// 메세지 ID 를 Caffeine Cache 로 각 메세지마다의 TTL 을 걸수있음
-		processedMessages.put(messageId, true);
-		System.out.println("WebSocket 송신: memberId= " + memberId + ", message= " + message);
+		try {
+			// WebSocket 에 메세지 전송
+			webSocketHandler.sendMessageToUser(memberId, message);
+
+			// 메세지 ID 를 Caffeine Cache 로 각 메세지마다의 TTL 을 걸수있음
+			processedMessages.put(messageId, true);
+			System.out.println("WebSocket 송신: memberId= " + memberId + ", message= " + message);
+		} catch (Exception e) {
+			System.out.println("WebSocket 송신 실패, 재시도 큐에 추가: " + message);
+			retryQueue.add(new NotificationMessage(memberId, message, messageId));
+		}
 	}
 
+	@Scheduled(fixedRate = 10000) // 10초마다 메서드 실행
+	public void retryFailedMessages() {
+		while (!retryQueue.isEmpty()) {
+			NotificationMessage message = retryQueue.poll();
+
+			if (processedMessages.getIfPresent(message.getMessageId()) != null) {
+				System.out.println("재시도. 중복 메세지 필터링 Message ID: " + message.getMessageId());
+				continue;
+			}
+
+			try {
+				// 메세지 재전송
+				webSocketHandler.sendMessageToUser(message.getMemberId(), message.getMessage());
+
+				// 성공한 메세지 저장
+				processedMessages.put(message.getMessageId(), true);
+				System.out.println("재시도 메세지 전송 성공 Message ID: " + message.getMessageId());
+			} catch (Exception e) {
+				// 재시도 실패시 큐 에 추가
+				System.out.println("재시도 메세지 전송 실패, 다시 큐에 추가합니다.");
+				retryQueue.add(message);
+			}
+		}
+	}
+
+	/**
+	 * 아래는 내부 편의 메서드
+	 */
 	private String extractMessageId(String message) {
-		return message.hashCode() + "";
+		return String.valueOf(message.hashCode());
+	}
+
+	@RequiredArgsConstructor
+	@Getter
+	private static class NotificationMessage {
+		private final Long memberId;
+		private final String message;
+		private final String messageId;
 	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. "어떻게 수정했는가?" 보다 "무엇을 왜 수정했는지?" 설명해주세요. -->
- 메세지를 Queue 자료구조에 저장하고, 10초에 한번씩 알림을 다시 보내는 기능 수행
- 메세지는 poll() 메서드로 꺼내지기 때문에 재전송에 성공하면 Queue 에 다시저장되지 않음
<!---- Resolves: #189   -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).