### PR TITLE
사장 주문 상태 변경시 일괄 메세지 처리

### DIFF
--- a/src/main/java/com/sparta/chairingproject/config/redis/RedisConfig.java
+++ b/src/main/java/com/sparta/chairingproject/config/redis/RedisConfig.java
@@ -1,9 +1,13 @@
 package com.sparta.chairingproject.config.redis;
 
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -15,15 +19,15 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
-	@Value("${spring.data.redis.host}")
-	private String host;
-
-	@Value("${spring.data.redis.port}")
-	private int port;
-
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+			.commandTimeout(Duration.ofSeconds(2))
+			.shutdownTimeout(Duration.ofMillis(100))
+			.build();
+
+		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+		return new LettuceConnectionFactory(redisConfig, clientConfig);
 	}
 
 	@Bean
@@ -32,16 +36,6 @@ public class RedisConfig {
 		template.setConnectionFactory(redisConnectionFactory);
 		template.setKeySerializer(new StringRedisSerializer());
 		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-		return template;
-	}
-
-	// Todo: 이부분은 RedisTemplate 충돌이 일어날까봐 일단은 따로 분리해서 구현할 계획
-	@Bean
-	public RedisTemplate<String, Object> redisTemplate2(RedisConnectionFactory connectionFactory) {
-		RedisTemplate<String, Object> template = new RedisTemplate<>();
-		template.setConnectionFactory(connectionFactory);
-		template.setKeySerializer(new StringRedisSerializer());
-		template.setValueSerializer(new StringRedisSerializer());
 		return template;
 	}
 

--- a/src/main/java/com/sparta/chairingproject/config/redis/RedisInitializer.java
+++ b/src/main/java/com/sparta/chairingproject/config/redis/RedisInitializer.java
@@ -1,0 +1,25 @@
+package com.sparta.chairingproject.config.redis;
+
+import java.util.Set;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisInitializer {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void clearRedisData() {
+		Set<String> keys = redisTemplate.keys("store:*");
+		if (keys != null) {
+			redisTemplate.delete(keys);
+		}
+		System.out.println("Redis 대기열 초기화 완료");
+	}
+}

--- a/src/main/java/com/sparta/chairingproject/domain/order/publisher/OrderStatusPublisher.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/publisher/OrderStatusPublisher.java
@@ -27,4 +27,14 @@ public class OrderStatusPublisher {
 			throw new RuntimeException("메시지 발행 실패", e);
 		}
 	}
+
+	public void publishStoreStatus(Long storeId, String message) {
+		String channel = "store-waiting-status:" + storeId;
+		redisTemplate.convertAndSend(channel, message);
+	}
+
+	public void publishMemberStatus(Long memberId, String message) {
+		String channel = "member-status:" + memberId;
+		redisTemplate.convertAndSend(channel, message);
+	}
 }

--- a/src/main/java/com/sparta/chairingproject/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/service/OrderService.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sparta.chairingproject.config.exception.customException.GlobalException;
 import com.sparta.chairingproject.config.transaction.AfterCommitAction;
 import com.sparta.chairingproject.domain.common.dto.RequestDto;
@@ -46,6 +45,7 @@ public class OrderService {
 	private final StoreRepository storeRepository;
 	private final OrderStatusPublisher orderStatusPublisher;
 	private final RedisSubscriberService redisSubscriberService;
+	private final WaitingQueueService waitingQueueService;
 
 	@Transactional
 	public OrderResponse createOrder(Long storeId, Member authMember,
@@ -68,14 +68,12 @@ public class OrderService {
 			}
 		}
 
-		OrderStatus orderStatus = OrderStatus.WAITING;
-
-		// 가게에 여유 테이블이 있는 경우 바로 입장 가능하면 ADMISSION 상태로 변경
-		int inProgressOrders = orderRepository.countByStoreIdAndStatus(storeId,
-			OrderStatus.IN_PROGRESS);
-		if (inProgressOrders < store.getTableCount()) {
-			orderStatus = OrderStatus.ADMISSION; // 여유 테이블이 있으면 바로 입장
-		}
+		// 초기 주문 상태 설정
+		int waitingOrders = waitingQueueService.getWaitingQueue(storeId).size();
+		int inProgressOrders = orderRepository.countByStoreIdAndStatus(storeId, OrderStatus.IN_PROGRESS);
+		OrderStatus orderStatus = (waitingOrders == 0 && inProgressOrders < store.getTableCount())
+			? OrderStatus.ADMISSION
+			: OrderStatus.WAITING;
 
 		Order order = Order.createOf(
 			authMember,
@@ -86,13 +84,25 @@ public class OrderService {
 		);
 		orderRepository.save(order);
 
-		// Redis 채널 구독
-		redisSubscriberService.subscribeToChannel(authMember.getId());
+		if (orderStatus.equals(OrderStatus.WAITING)) {
+			waitingQueueService.addToWaitingQueue(storeId, authMember.getId());
+		}
 
 		AfterCommitAction.register(() -> {
-			// Redis 채널 메시지 발행
-			String message = "고객님의 주문 (주문 ID: " + order.getId() + ") 이 요청되었습니다.";
-			orderStatusPublisher.publishOrderStatus(authMember.getId(), order.getId(), message);
+			// Redis 채널 구독
+			redisSubscriberService.subscribeToChannel(storeId);
+			redisSubscriberService.subscribeToMemberChannel(authMember.getId());
+
+			// 개인 메시지 발행 (대기 순서 메시지는 개인 채널로만 전송)
+			if (orderStatus == OrderStatus.WAITING) {
+				List<String> waitingQueue = waitingQueueService.getWaitingQueue(storeId);
+				int userPosition = waitingQueue.indexOf(String.valueOf(authMember.getId())) + 1;
+				String personalMessage = "주문이 생성되었습니다. 현재 대기 순서: " + userPosition;
+				orderStatusPublisher.publishMemberStatus(authMember.getId(), personalMessage);
+			} else {
+				String personalMessage = "입장 처리되었습니다.";
+				orderStatusPublisher.publishMemberStatus(authMember.getId(), personalMessage);
+			}
 		});
 
 		int waitingTeams = orderRepository.countByStoreIdAndStatus(storeId, OrderStatus.WAITING);
@@ -139,8 +149,7 @@ public class OrderService {
 		Store store = storeRepository.findById(storeId)
 			.orElseThrow(() -> new GlobalException(NOT_FOUND_STORE));
 
-		int inProgressOrders = orderRepository.countByStoreIdAndStatus(storeId,
-			OrderStatus.IN_PROGRESS);
+		int inProgressOrders = orderRepository.countByStoreIdAndStatus(storeId, OrderStatus.IN_PROGRESS);
 
 		// 처음 웨이팅 걸었을때 가게 상황에 맞춰 바로 입장(ADMISSION) or 웨이팅 으로 설정
 		OrderStatus orderStatus = (inProgressOrders < store.getTableCount())
@@ -155,13 +164,25 @@ public class OrderService {
 		);
 		orderRepository.save(order);
 
-		// Redis 채널 구독
-		redisSubscriberService.subscribeToChannel(member.getId());
+		if (orderStatus.equals(OrderStatus.WAITING)) {
+			waitingQueueService.addToWaitingQueue(storeId, member.getId());
+		}
 
 		AfterCommitAction.register(() -> {
-			// Redis 채널 메시지 발행
-			String message = "고객님의 주문 (주문 ID: " + order.getId() + ") 이 요청되었습니다.";
-			orderStatusPublisher.publishOrderStatus(member.getId(), order.getId(), message);
+			// Redis 채널 구독
+			redisSubscriberService.subscribeToChannel(storeId);
+			redisSubscriberService.subscribeToMemberChannel(member.getId());
+
+			// 개인 메시지 발행 (대기 순서 메시지는 개인 채널로만 전송)
+			if (orderStatus == OrderStatus.WAITING) {
+				List<String> waitingQueue = waitingQueueService.getWaitingQueue(storeId);
+				int userPosition = waitingQueue.indexOf(String.valueOf(member.getId())) + 1;
+				String personalMessage = "주문이 생성되었습니다. 현재 대기 순서: " + userPosition;
+				orderStatusPublisher.publishMemberStatus(member.getId(), personalMessage);
+			} else {
+				String personalMessage = "입장 처리되었습니다.";
+				orderStatusPublisher.publishMemberStatus(member.getId(), personalMessage);
+			}
 		});
 
 		int waitingTeams = orderRepository.countByStoreIdAndStatus(storeId, OrderStatus.WAITING);
@@ -175,7 +196,7 @@ public class OrderService {
 
 	@Transactional
 	public OrderStatusUpdateResponse updateOrderStatus(Long storeId, Long orderId, OrderStatusUpdateRequest request,
-		Member member) throws JsonProcessingException {
+		Member member) {
 		Store store = storeRepository.findById(storeId) //가게 검증
 			.orElseThrow(() -> new GlobalException(NOT_FOUND_STORE));
 		if (!store.getOwner().getId().equals(member.getId())) {
@@ -213,9 +234,20 @@ public class OrderService {
 		orderRepository.save(order);
 
 		AfterCommitAction.register(() -> {
-			// Redis 로 메시지 발행
-			String message = "주문 상태가 업데이트되었습니다: " + newStatus.name();
-			orderStatusPublisher.publishOrderStatus(order.getMember().getId(), order.getId(), message);
+			if (newStatus == OrderStatus.ADMISSION || newStatus == OrderStatus.CANCELLED) {
+				waitingQueueService.removeFromWaitingQueue(storeId, order.getMember().getId());
+				String personalMessage = newStatus == OrderStatus.ADMISSION
+					? "입장 처리되었습니다."
+					: "주문이 취소되었습니다.";
+				orderStatusPublisher.publishMemberStatus(order.getMember().getId(), personalMessage);
+			}
+
+			List<String> queue = waitingQueueService.getWaitingQueue(storeId);
+			for (int i = 0; i < queue.size(); i++) {
+				Long memberId = Long.valueOf(queue.get(i));
+				String queueMessage = "현재 대기 순서: " + (i + 1) + ", 총 대기: " + queue.size();
+				orderStatusPublisher.publishStoreStatus(storeId, queueMessage);
+			}
 		});
 
 		return OrderStatusUpdateResponse.builder()

--- a/src/main/java/com/sparta/chairingproject/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/service/OrderService.java
@@ -75,13 +75,7 @@ public class OrderService {
 			? OrderStatus.ADMISSION
 			: OrderStatus.WAITING;
 
-		Order order = Order.createOf(
-			authMember,
-			store,
-			menus,
-			orderStatus,
-			totalPrice
-		);
+		Order order = Order.createOf(authMember, store, menus, orderStatus, totalPrice);
 		orderRepository.save(order);
 
 		if (orderStatus.equals(OrderStatus.WAITING)) {
@@ -155,13 +149,7 @@ public class OrderService {
 		OrderStatus orderStatus = (inProgressOrders < store.getTableCount())
 			? OrderStatus.ADMISSION : OrderStatus.WAITING;
 
-		Order order = Order.createOf(
-			member,
-			store,
-			Collections.emptyList(),
-			orderStatus,
-			0
-		);
+		Order order = Order.createOf(member, store, Collections.emptyList(), orderStatus, 0);
 		orderRepository.save(order);
 
 		if (orderStatus.equals(OrderStatus.WAITING)) {
@@ -246,7 +234,7 @@ public class OrderService {
 			for (int i = 0; i < queue.size(); i++) {
 				Long memberId = Long.valueOf(queue.get(i));
 				String queueMessage = "현재 대기 순서: " + (i + 1) + ", 총 대기: " + queue.size();
-				orderStatusPublisher.publishStoreStatus(storeId, queueMessage);
+				orderStatusPublisher.publishMemberStatus(memberId, queueMessage);
 			}
 		});
 

--- a/src/main/java/com/sparta/chairingproject/domain/order/service/RedisSubscriberService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/service/RedisSubscriberService.java
@@ -15,7 +15,7 @@ public class RedisSubscriberService {
 	private final OrderNotificationService orderNotificationService;
 
 	public void subscribeToChannel(Long storeId) {
-		String channel = "order-status:store:" + storeId;
+		String channel = "store-waiting-status:" + storeId;
 		MessageListener listener = (message, pattern) -> {
 			String payload = new String(message.getBody());
 			System.out.println("Redis 메세지 수신: " + payload);

--- a/src/main/java/com/sparta/chairingproject/domain/order/service/RedisSubscriberService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/service/RedisSubscriberService.java
@@ -14,17 +14,28 @@ public class RedisSubscriberService {
 	private final RedisMessageListenerContainer listenerContainer;
 	private final OrderNotificationService orderNotificationService;
 
-	public void subscribeToChannel(Long memberId) {
-		String channel = "order-status:member:" + memberId;
+	public void subscribeToChannel(Long storeId) {
+		String channel = "order-status:store:" + storeId;
 		MessageListener listener = (message, pattern) -> {
 			String payload = new String(message.getBody());
 			System.out.println("Redis 메세지 수신: " + payload);
 
-			orderNotificationService.sendNotification(memberId, payload);
+			orderNotificationService.sendNotification(storeId, payload);
 		};
 
 		ChannelTopic topic = new ChannelTopic(channel);
 		listenerContainer.addMessageListener(listener, topic);
+		System.out.println("Redis 채널 구독 성공: channel=" + channel);
+	}
+
+	public void subscribeToMemberChannel(Long memberId) {
+		String channel = "member-status:" + memberId;
+		MessageListener listener = (message, pattern) -> {
+			String payload = new String(message.getBody());
+			orderNotificationService.sendNotificationToMember(memberId, payload);
+		};
+
+		listenerContainer.addMessageListener(listener, new ChannelTopic(channel));
 		System.out.println("Redis 채널 구독 성공: channel=" + channel);
 	}
 }

--- a/src/main/java/com/sparta/chairingproject/domain/order/service/WaitingQueueService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/service/WaitingQueueService.java
@@ -14,7 +14,7 @@ public class WaitingQueueService {
 
 	public void addToWaitingQueue(Long storeId, Long memberId) {
 		String queueKey = "store:" + storeId + ":waiting";
-		redisTemplate.opsForList().leftPush(queueKey, String.valueOf(memberId));
+		redisTemplate.opsForList().rightPush(queueKey, String.valueOf(memberId));
 	}
 
 	public void removeFromWaitingQueue(Long storeId, Long memberId) {

--- a/src/main/java/com/sparta/chairingproject/domain/order/service/WaitingQueueService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/order/service/WaitingQueueService.java
@@ -1,0 +1,29 @@
+package com.sparta.chairingproject.domain.order.service;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WaitingQueueService {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void addToWaitingQueue(Long storeId, Long memberId) {
+		String queueKey = "store:" + storeId + ":waiting";
+		redisTemplate.opsForList().leftPush(queueKey, String.valueOf(memberId));
+	}
+
+	public void removeFromWaitingQueue(Long storeId, Long memberId) {
+		String queueKey = "store:" + storeId + ":waiting";
+		redisTemplate.opsForList().remove(queueKey, 1, String.valueOf(memberId));
+	}
+
+	public List<String> getWaitingQueue(Long storeId) {
+		String queueKey = "store:" + storeId + ":waiting";
+		return redisTemplate.opsForList().range(queueKey, 0, -1);
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,4 +12,4 @@ spring.cache.redis.time-to-live=600000
 spring.cache.redis.cache-null-values=false
 jwt.secret.key=7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg==
 logging.level.org.springframework.cache=debug
-logging.level.org.springframework.data.redis=debug
+logging.level.org.springframework.data.redis=info


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. "어떻게 수정했는가?" 보다 "무엇을 왜 수정했는지?" 설명해주세요. -->
- 사장이 주문 상태를 변경하면 웨이팅인 회원들에게 일괄로 메세지를 전송
- 주문을 하거나, 웨이팅을 거는 사람에게 웨이팅 큐에 저장
- 주문 상태를 변경하면 웨이팅을 하고있는 유저에게만 대기 변경 메세지 전달
- WAITING 에서 ADMISSION 또는 CANCELLED 로 변경되면 대기열 이탈
<!---- Resolves: #198  -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).