### PR TITLE
쿠폰 발급 동시성 제어

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+
+    implementation 'org.redisson:redisson-spring-boot-starter:3.22.1'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/sparta/chairingproject/config/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/sparta/chairingproject/config/exception/enums/ExceptionCode.java
@@ -100,6 +100,7 @@ public enum ExceptionCode {
 	COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 쿠폰을 찾을 수 없습니다."),
 	COUPON_ALREADY_ISSUED(HttpStatus.CONFLICT, "이미 해당 쿠폰을 발급받았습니다."),
 	COUPON_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 쿠폰 이름입니다."),
+	LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT,"동시에 너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요."),
 
 	//권한
 	ONLY_OWNER_ALLOWED(HttpStatus.FORBIDDEN, "사장님만 가능합니다"),

--- a/src/main/java/com/sparta/chairingproject/config/redis/RedissonConfig.java
+++ b/src/main/java/com/sparta/chairingproject/config/redis/RedissonConfig.java
@@ -1,4 +1,4 @@
-package com.sparta.chairingproject.config.redissonConfig;
+package com.sparta.chairingproject.config.redis;
 
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;

--- a/src/main/java/com/sparta/chairingproject/config/redissonConfig/RedissonConfig.java
+++ b/src/main/java/com/sparta/chairingproject/config/redissonConfig/RedissonConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.chairingproject.config.redissonConfig;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer()
+			.setAddress("redis://localhost:6379")
+			.setPassword(null); // 비밀번호가 설정되어 있으면 추가
+		return Redisson.create(config);
+	}
+}

--- a/src/main/java/com/sparta/chairingproject/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/coupon/service/CouponService.java
@@ -2,7 +2,6 @@ package com.sparta.chairingproject.domain.coupon.service;
 
 import static com.sparta.chairingproject.config.exception.enums.ExceptionCode.*;
 
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RLock;
@@ -10,7 +9,6 @@ import org.redisson.api.RedissonClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
@@ -61,49 +59,16 @@ public class CouponService {
 	@Transactional
 	public void issueCoupon(Long couponId, RequestDto request, Member member) {
 		String lockKey = "coupon:" + couponId;
-		String sortedSetKey = "coupon_queue:" + couponId;
-		RLock lock = redissonClient.getLock(lockKey);
-		long currentTime = System.nanoTime(); // 요청 순서를 보장하기 위한 타임스탬프
-		long threadId = Thread.currentThread().getId();
-		long uniqueTimestamp = currentTime + threadId;
+		RLock lock = redissonClient.getFairLock(lockKey);
 
 		try {
-			// 락 획득 시도 (최대 5초 대기, 10초 유지)
-			if (!lock.tryLock(5, 10, TimeUnit.SECONDS)) {
-				throw new IllegalStateException("동시에 너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요.");
+			// 락 획득 시도 (최대 1초 대기, 10초 유지)
+			System.out.println("대기중: " + Thread.currentThread().getId());
+			if (!lock.tryLock(1, 10, TimeUnit.SECONDS)) {
+				throw new GlobalException(LOCK_ACQUISITION_FAILED);
 			}
+			System.out.println("Thread " + Thread.currentThread().getId() + "락 획득.");
 
-			// Lua 스크립트로 원자적 작업 수행
-			String luaScript = """
-				    local sortedSetKey = KEYS[1]
-				    local memberId = ARGV[1]
-				    local timestamp = ARGV[2]
-
-				    redis.call('ZADD', sortedSetKey, timestamp, memberId)
-				    local minMember = redis.call('ZRANGE', sortedSetKey, 0, 0)[1]
-
-				    if minMember == memberId then
-				        return true
-				    else
-				        return false
-				    end
-				""";
-
-			DefaultRedisScript<Boolean> script = new DefaultRedisScript<>();
-			script.setScriptText(luaScript);
-			script.setResultType(Boolean.class);
-
-			Boolean isEligible = redisTemplate.execute(
-				script,
-				Collections.singletonList(sortedSetKey),
-				String.valueOf(member.getId()), String.valueOf(uniqueTimestamp) // uniqueTimestamp 전달
-			);
-
-			if (Boolean.FALSE.equals(isEligible)) {
-				throw new IllegalStateException("선착순이 아니므로 쿠폰을 발급할 수 없습니다.");
-			}
-
-			// 쿠폰 발급 처리
 			Coupon coupon = couponRepository.findById(couponId)
 				.orElseThrow(() -> new GlobalException(COUPON_NOT_FOUND));
 
@@ -119,69 +84,22 @@ public class CouponService {
 				.coupon(coupon)
 				.build();
 			issuanceRepository.save(issuance);
-
-			// 발급 완료 후 요청 삭제
-			redisTemplate.opsForZSet().remove(sortedSetKey, String.valueOf(member.getId()));
 		} catch (InterruptedException e) {
-			throw new IllegalArgumentException("Redis 락을 획득하는데 실패했습니다.", e);
+			System.out.println("Thread " + Thread.currentThread().getId() + " was interrupted.");
+			throw new IllegalArgumentException("스레드 인터럽트로 인해 락 획득이 실패했습니다.", e);
 		} finally {
+			// 트랜잭션이 끝난 후에 락 해제를 보장
 			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
 				@Override
 				public void afterCompletion(int status) {
 					if (lock.isHeldByCurrentThread()) {
 						lock.unlock();
-						// System.out.println("Thread " + Thread.currentThread().getId() + " released lock.");
+						System.out.println("Thread " + Thread.currentThread().getId() + " released lock.");
 					}
 				}
 			});
 		}
 	}
-
-	// // 초기 코드
-	// @Transactional
-	// public void issueCoupon(Long couponId, RequestDto request, Member member) {
-	// 	// Redis 락
-	// 	String lockKey = "coupon:" + couponId;
-	// 	RLock lock = redissonClient.getFairLock(lockKey);
-	//
-	// 	try {
-	// 		// 락 획득 시도 (최대 5초 대기, 10초 유지)
-	// 		if (!lock.tryLock(1, 10, TimeUnit.SECONDS)) {
-	// 			System.out.println("Thread " + Thread.currentThread().getId() + "락 획득 실패.");
-	// 			throw new IllegalStateException("동시에 너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요.");
-	// 		}
-	// 		// System.out.println("Thread " + Thread.currentThread().getId() + "락 획득.");
-	//
-	// 		Coupon coupon = couponRepository.findById(couponId)
-	// 			.orElseThrow(() -> new GlobalException(COUPON_NOT_FOUND));
-	//
-	// 		if (issuanceRepository.findByMemberIdAndCouponId(member.getId(), couponId).isPresent()) {
-	// 			throw new GlobalException(COUPON_ALREADY_ISSUED);
-	// 		}
-	//
-	// 		coupon.validateQuantity();
-	// 		coupon.decreaseQuantity();
-	//
-	// 		Issuance issuance = Issuance.builder()
-	// 			.member(member)
-	// 			.coupon(coupon)
-	// 			.build();
-	// 		issuanceRepository.save(issuance);
-	// 	} catch (InterruptedException e) {
-	// 		System.out.println("Thread " + Thread.currentThread().getId() + " was interrupted.");
-	// 		throw new IllegalArgumentException("Redis 락을 획득하는데 실패했습니다.", e);
-	// 	} finally {
-	// 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
-	// 			@Override
-	// 			public void afterCompletion(int status) {
-	// 				if (lock.isHeldByCurrentThread()) {
-	// 					lock.unlock();
-	// 					System.out.println("Thread " + Thread.currentThread().getId() + " released lock.");
-	// 				}
-	// 			}
-	// 		});
-	// 	}
-	// }
 
 	public Page<CouponResponse> getAllCoupons(RequestDto request, PageRequest pageRequest) {
 		Page<Coupon> coupons = couponRepository.findAll(pageRequest);

--- a/src/main/java/com/sparta/chairingproject/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/chairingproject/domain/coupon/service/CouponService.java
@@ -2,12 +2,15 @@ package com.sparta.chairingproject.domain.coupon.service;
 
 import static com.sparta.chairingproject.config.exception.enums.ExceptionCode.*;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
@@ -31,6 +34,7 @@ public class CouponService {
 	private final CouponRepository couponRepository;
 	private final IssuanceRepository issuanceRepository;
 	private final RedissonClient redissonClient;
+	private final RedisTemplate<String, String> redisTemplate; // FIFO 큐 역할
 
 	public CouponResponse createCoupon(CouponRequest request) {
 		if (couponRepository.existsByName(request.getName())) {
@@ -56,29 +60,50 @@ public class CouponService {
 
 	@Transactional
 	public void issueCoupon(Long couponId, RequestDto request, Member member) {
-		// Redis 락
 		String lockKey = "coupon:" + couponId;
+		String sortedSetKey = "coupon_queue:" + couponId;
 		RLock lock = redissonClient.getLock(lockKey);
+		long currentTime = System.nanoTime(); // 요청 순서를 보장하기 위한 타임스탬프
+		long threadId = Thread.currentThread().getId();
+		long uniqueTimestamp = currentTime + threadId;
 
 		try {
 			// 락 획득 시도 (최대 5초 대기, 10초 유지)
-			if (!lock.tryLock(1, 10, TimeUnit.SECONDS)) {
-				System.out.println("Thread " + Thread.currentThread().getId() + "락 획득 실패.");
+			if (!lock.tryLock(5, 10, TimeUnit.SECONDS)) {
 				throw new IllegalStateException("동시에 너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요.");
 			}
-			System.out.println("Thread " + Thread.currentThread().getId() + "락 획득.");
 
-			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
-				@Override
-				public void afterCompletion(int status) {
-					if (lock.isHeldByCurrentThread()) {
-						lock.unlock();
-						System.out.println("Thread " + Thread.currentThread().getId() + " released lock.");
-					}
-				}
-			});
+			// Lua 스크립트로 원자적 작업 수행
+			String luaScript = """
+				    local sortedSetKey = KEYS[1]
+				    local memberId = ARGV[1]
+				    local timestamp = ARGV[2]
 
-			// sampleService.issue(couponId, request, member);
+				    redis.call('ZADD', sortedSetKey, timestamp, memberId)
+				    local minMember = redis.call('ZRANGE', sortedSetKey, 0, 0)[1]
+
+				    if minMember == memberId then
+				        return true
+				    else
+				        return false
+				    end
+				""";
+
+			DefaultRedisScript<Boolean> script = new DefaultRedisScript<>();
+			script.setScriptText(luaScript);
+			script.setResultType(Boolean.class);
+
+			Boolean isEligible = redisTemplate.execute(
+				script,
+				Collections.singletonList(sortedSetKey),
+				String.valueOf(member.getId()), String.valueOf(uniqueTimestamp) // uniqueTimestamp 전달
+			);
+
+			if (Boolean.FALSE.equals(isEligible)) {
+				throw new IllegalStateException("선착순이 아니므로 쿠폰을 발급할 수 없습니다.");
+			}
+
+			// 쿠폰 발급 처리
 			Coupon coupon = couponRepository.findById(couponId)
 				.orElseThrow(() -> new GlobalException(COUPON_NOT_FOUND));
 
@@ -94,11 +119,69 @@ public class CouponService {
 				.coupon(coupon)
 				.build();
 			issuanceRepository.save(issuance);
+
+			// 발급 완료 후 요청 삭제
+			redisTemplate.opsForZSet().remove(sortedSetKey, String.valueOf(member.getId()));
 		} catch (InterruptedException e) {
-			System.out.println("Thread " + Thread.currentThread().getId() + " was interrupted.");
 			throw new IllegalArgumentException("Redis 락을 획득하는데 실패했습니다.", e);
+		} finally {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+				@Override
+				public void afterCompletion(int status) {
+					if (lock.isHeldByCurrentThread()) {
+						lock.unlock();
+						// System.out.println("Thread " + Thread.currentThread().getId() + " released lock.");
+					}
+				}
+			});
 		}
 	}
+
+	// // 초기 코드
+	// @Transactional
+	// public void issueCoupon(Long couponId, RequestDto request, Member member) {
+	// 	// Redis 락
+	// 	String lockKey = "coupon:" + couponId;
+	// 	RLock lock = redissonClient.getFairLock(lockKey);
+	//
+	// 	try {
+	// 		// 락 획득 시도 (최대 5초 대기, 10초 유지)
+	// 		if (!lock.tryLock(1, 10, TimeUnit.SECONDS)) {
+	// 			System.out.println("Thread " + Thread.currentThread().getId() + "락 획득 실패.");
+	// 			throw new IllegalStateException("동시에 너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요.");
+	// 		}
+	// 		// System.out.println("Thread " + Thread.currentThread().getId() + "락 획득.");
+	//
+	// 		Coupon coupon = couponRepository.findById(couponId)
+	// 			.orElseThrow(() -> new GlobalException(COUPON_NOT_FOUND));
+	//
+	// 		if (issuanceRepository.findByMemberIdAndCouponId(member.getId(), couponId).isPresent()) {
+	// 			throw new GlobalException(COUPON_ALREADY_ISSUED);
+	// 		}
+	//
+	// 		coupon.validateQuantity();
+	// 		coupon.decreaseQuantity();
+	//
+	// 		Issuance issuance = Issuance.builder()
+	// 			.member(member)
+	// 			.coupon(coupon)
+	// 			.build();
+	// 		issuanceRepository.save(issuance);
+	// 	} catch (InterruptedException e) {
+	// 		System.out.println("Thread " + Thread.currentThread().getId() + " was interrupted.");
+	// 		throw new IllegalArgumentException("Redis 락을 획득하는데 실패했습니다.", e);
+	// 	} finally {
+	// 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+	// 			@Override
+	// 			public void afterCompletion(int status) {
+	// 				if (lock.isHeldByCurrentThread()) {
+	// 					lock.unlock();
+	// 					System.out.println("Thread " + Thread.currentThread().getId() + " released lock.");
+	// 				}
+	// 			}
+	// 		});
+	// 	}
+	// }
 
 	public Page<CouponResponse> getAllCoupons(RequestDto request, PageRequest pageRequest) {
 		Page<Coupon> coupons = couponRepository.findAll(pageRequest);

--- a/src/test/java/com/sparta/chairingproject/domain/coupon/service/CouponConcurrencyTest.java
+++ b/src/test/java/com/sparta/chairingproject/domain/coupon/service/CouponConcurrencyTest.java
@@ -66,22 +66,22 @@ public class CouponConcurrencyTest {
 	}
 
 	@Test
-	@DisplayName("Redis 락 동시성 제어 테스트")
+	@DisplayName("Redis 락 동시성 제어 & 순서 제어 테스트")
 	void redisLockConcurrencyTest() throws InterruptedException {
 		for (int i = 0; i < threadCount; i++) {
 			int threadId = i;
 			executorService.submit(() -> {
 				try {
-					System.out.println("Thread 시작: " + threadId);
+					// System.out.println("Thread 시작: " + Thread.currentThread().getId());
 					Member threadMember = new Member("Test User" + threadId, "test" + threadId + "@example.com",
 						"password", MemberRole.USER);
 					memberRepository.save(threadMember);
 					couponService.issueCoupon(coupon.getId(), new RequestDto(threadMember.getId()), threadMember);
 				} catch (GlobalException e) {
-					System.out.println("Thread 예외: " + threadId + ", " + e.getMessage());
+					System.out.println("Thread 예외: " + Thread.currentThread().getId() + ", " + e.getMessage());
 				} finally {
 					latch.countDown();
-					System.out.println("Thread 완료: " + threadId);
+					// System.out.println("Thread 완료: " + Thread.currentThread().getId());
 				}
 			});
 		}
@@ -96,5 +96,4 @@ public class CouponConcurrencyTest {
 		assertEquals(0, updatedCoupon.getQuantity());
 		assertEquals(100, issuanceRepository.count());
 	}
-
 }

--- a/src/test/java/com/sparta/chairingproject/domain/coupon/service/CouponConcurrencyTest.java
+++ b/src/test/java/com/sparta/chairingproject/domain/coupon/service/CouponConcurrencyTest.java
@@ -1,0 +1,100 @@
+package com.sparta.chairingproject.domain.coupon.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.sparta.chairingproject.config.exception.customException.GlobalException;
+import com.sparta.chairingproject.domain.Issuance.repository.IssuanceRepository;
+import com.sparta.chairingproject.domain.common.dto.RequestDto;
+import com.sparta.chairingproject.domain.coupon.entity.Coupon;
+import com.sparta.chairingproject.domain.coupon.repository.CouponRepository;
+import com.sparta.chairingproject.domain.member.entity.Member;
+import com.sparta.chairingproject.domain.member.entity.MemberRole;
+import com.sparta.chairingproject.domain.member.repository.MemberRepository;
+
+@SpringBootTest
+public class CouponConcurrencyTest {
+
+	@Autowired
+	private CouponService couponService;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private IssuanceRepository issuanceRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Coupon coupon;
+	private Member member;
+	private int threadCount;
+	private ExecutorService executorService;
+	private CountDownLatch latch;
+
+	@BeforeEach
+	void setUp() {
+		member = new Member("Test User", "test@example.com", "password", MemberRole.USER);
+		memberRepository.save(member);
+		coupon = Coupon.builder()
+			.name("Test Coupon")
+			.quantity(100)
+			.discountPrice(500)
+			.build();
+		couponRepository.save(coupon);
+		threadCount = 100;
+		executorService = Executors.newFixedThreadPool(threadCount);
+		latch = new CountDownLatch(threadCount);
+	}
+
+	@AfterEach
+	void tearDown() {
+		issuanceRepository.deleteAll();
+		couponRepository.deleteAll();
+		memberRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("Redis 락 동시성 제어 테스트")
+	void redisLockConcurrencyTest() throws InterruptedException {
+		for (int i = 0; i < threadCount; i++) {
+			int threadId = i;
+			executorService.submit(() -> {
+				try {
+					System.out.println("Thread 시작: " + threadId);
+					Member threadMember = new Member("Test User" + threadId, "test" + threadId + "@example.com",
+						"password", MemberRole.USER);
+					memberRepository.save(threadMember);
+					couponService.issueCoupon(coupon.getId(), new RequestDto(threadMember.getId()), threadMember);
+				} catch (GlobalException e) {
+					System.out.println("Thread 예외: " + threadId + ", " + e.getMessage());
+				} finally {
+					latch.countDown();
+					System.out.println("Thread 완료: " + threadId);
+				}
+			});
+		}
+
+		latch.await();
+
+		// 결과 검증
+		Coupon updatedCoupon = couponRepository.findById(coupon.getId()).orElseThrow();
+		System.out.println("남은 쿠폰 수량: " + updatedCoupon.getQuantity());
+		System.out.println("발급된 쿠폰 수량: " + issuanceRepository.count());
+
+		assertEquals(0, updatedCoupon.getQuantity());
+		assertEquals(100, issuanceRepository.count());
+	}
+
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. "어떻게 수정했는가?" 보다 "무엇을 왜 수정했는지?" 설명해주세요. -->
- RLock 인터페이스를 사용하여 Redis 기반의 락 구현.
- TransactionSynchronizationManager.registerSynchronization를 사용하여 트랜잭션 종료 시 락 해제 로직을 등록.
- 기존 RedissonClient.getLock 대신 getFairLock을 사용하여 요청 처리 순서를 보장.
- Redis 락 동시성 제어 및 순서 테스트:
다중 스레드 환경에서 동시 요청을 처리하며, FIFO 순서 보장이 성공적으로 작동하는지 검증. (직접 로그를 확인해야 함)
남은 쿠폰 수량과 발급된 쿠폰 수량이 정확히 일치하는지 확인.
- pr은 올리지 않으나 #170 : 비관적락 동시성 제어, #196: 낙관적락 동시성 제어 구현 및 테스트

- 다음 계획
 1. FairLock의 성능 테스트(nGrinder)
 2. Redis 락 성능 개선.
 3. 필요시 다른 api에도 동시성 제어 적용.
 4. java 레벨에서의 동시성 제어 구현 및 성능 비교.

<!---- Resolves: #173  -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).